### PR TITLE
Fix bai2json autoloads for global install

### DIFF
--- a/bin/bai2json
+++ b/bin/bai2json
@@ -3,7 +3,19 @@
 
 declare(strict_types=1);
 
-require 'vendor/autoload.php';
+// autoload dance /////////////////////////////////////////////////////
+                                                                     //
+$autoload = dirname(__DIR__) . '/vendor/autoload.php';               //
+if (!is_file($autoload)) {                                           //
+    $autoload = dirname(__DIR__, 4) . '/vendor/autoload.php';        //
+    if (!is_file($autoload)) {                                       //
+        die("Unable to find Composer autoload file.");               //
+    }                                                                //
+}                                                                    //
+                                                                     //
+require $autoload;                                                   //
+                                                                     //
+///////////////////////////////////////////////////////////////////////
 
 use STS\Bai2\Bai2;
 use STS\Bai2\Records\FileRecord;


### PR DESCRIPTION
Currently, when the Bai2 library is installed globally, the `bin2json` script tries to require the Composer autoloads in a fragile way that breaks. This commit allows the autoloads to be correctly loaded such that the `bai2json` script may be run correctly regardless of the context (global, project local, etc.) in which it's being executed in.

The following was useful in figuring out how to improve the autoload loading:

   - https://dev.to/erikaheidi/how-to-create-a-composer-bin-command-with-minicli-35ih#step-2-creating-a-raw-binminicli-endraw-script
   - https://www.php.net/manual/en/function.is-file.php
   - https://www.php.net/manual/en/function.dirname.php
   - https://www.phptutorial.net/php-tutorial/php-__dir__/

Closes #5.

Automated Test Results:

OK (1570 tests, 2671 assertions)