### PR TITLE
Allow spaces in "Customer Reference Number"

### DIFF
--- a/src/Parsers/TransactionParser.php
+++ b/src/Parsers/TransactionParser.php
@@ -56,7 +56,7 @@ final class TransactionParser extends AbstractRecordParser
 
         $this->parsed['customerReferenceNumber'] =
             $this->shiftAndParseField('Customer Reference Number')
-                 ->match('/^[[:alnum:]]+$/', 'must be alpha-numeric when provided')
+                 ->match('/^[a-zA-Z0-9 ]+$/', 'must be alpha-numeric when provided')
                  ->string(default: null);
 
         $this->parsed['text'] =

--- a/tests/Parsers/TransactionParserTest.php
+++ b/tests/Parsers/TransactionParserTest.php
@@ -836,6 +836,11 @@ final class TransactionParserTest extends RecordParserTestCase
      *           ["16,409,,,123456789,rstuvwxyz,TEXT OF SUCH IMPORT", "rstuvwxyz"]
      *           ["16,409,,,123456789,98765wxyz,TEXT OF SUCH IMPORT", "98765wxyz"]
      *           ["16,409,,,123456789,wxyz98765,TEXT OF SUCH IMPORT", "wxyz98765"]
+     *           ["16,409,,,123456789,WXyz98765,TEXT OF SUCH IMPORT", "WXyz98765"]
+     *           ["16,409,,,123456789,98765 wxyz,TEXT OF SUCH IMPORT", "98765 wxyz"]
+     *           ["16,409,,,123456789, 98765wxyz,TEXT OF SUCH IMPORT", " 98765wxyz"]
+     *           ["16,409,,,123456789,98765wxyz ,TEXT OF SUCH IMPORT", "98765wxyz "]
+     *           ["16,409,,,123456789, ,TEXT OF SUCH IMPORT", " "]
      *           ["16,409,,,123456789,000000009,TEXT OF SUCH IMPORT", "000000009"]
      *           ["16,409,,,123456789,thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark,TEXT OF SUCH IMPORT", "thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark"]
      */
@@ -854,13 +859,10 @@ final class TransactionParserTest extends RecordParserTestCase
     }
 
     /**
-     * @testWith ["16,409,,,123456789, 987654321,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789,987654321 ,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789,9876_54321,TEXT OF SUCH IMPORT"]
+     * @testWith ["16,409,,,123456789,9876_54321,TEXT OF SUCH IMPORT"]
      *           ["16,409,,,123456789,9876+54321,TEXT OF SUCH IMPORT"]
      *           ["16,409,,,123456789,9876-54321,TEXT OF SUCH IMPORT"]
      *           ["16,409,,,123456789,+_)(*&^%$,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789, ,TEXT OF SUCH IMPORT"]
      */
     public function testCustomerReferenceNumberInvalid(string $line): void
     {


### PR DESCRIPTION
We were previously using a very strict interpretation of the specification which did not permit spaces to be embedded within a Transaction (type-16) record's Customer Reference Number field. This was causing problems with data encountered in the real world. This commit makes our parser more permissive when it comes spaces within this field.

Fixes #6. Closes #7.

Automated Test Results:

OK (1571 tests, 2669 assertions)