### PR TITLE
Allow `&`, `#`, and `'` in "Customer Reference Number"

### DIFF
--- a/src/Parsers/TransactionParser.php
+++ b/src/Parsers/TransactionParser.php
@@ -56,7 +56,7 @@ final class TransactionParser extends AbstractRecordParser
 
         $this->parsed['customerReferenceNumber'] =
             $this->shiftAndParseField('Customer Reference Number')
-                 ->match('/^[a-zA-Z0-9 _-]+$/', 'must be alpha-numeric when provided')
+                 ->match('/^[a-zA-Z0-9 #&_-]+$/', 'must be alpha-numeric when provided')
                  ->string(default: null);
 
         $this->parsed['text'] =

--- a/src/Parsers/TransactionParser.php
+++ b/src/Parsers/TransactionParser.php
@@ -56,7 +56,7 @@ final class TransactionParser extends AbstractRecordParser
 
         $this->parsed['customerReferenceNumber'] =
             $this->shiftAndParseField('Customer Reference Number')
-                 ->match('/^[a-zA-Z0-9 #&_-]+$/', 'must be alpha-numeric when provided')
+                 ->match('/^[a-zA-Z0-9 #&\'_-]+$/', 'must be alpha-numeric when provided')
                  ->string(default: null);
 
         $this->parsed['text'] =

--- a/tests/Parsers/TransactionParserTest.php
+++ b/tests/Parsers/TransactionParserTest.php
@@ -849,6 +849,8 @@ final class TransactionParserTest extends RecordParserTestCase
      *           ["16,409,,,123456789,_98765wxyz,TEXT OF SUCH IMPORT", "_98765wxyz"]
      *           ["16,409,,,123456789,98765wxyz_,TEXT OF SUCH IMPORT", "98765wxyz_"]
      *           ["16,409,,,123456789,_,TEXT OF SUCH IMPORT", "_"]
+     *           ["16,409,,,123456789,foo & bar,TEXT OF SUCH IMPORT", "foo & bar"]
+     *           ["16,409,,,123456789,for acct #1337,TEXT OF SUCH IMPORT", "for acct #1337"]
      *           ["16,409,,,123456789,000000009,TEXT OF SUCH IMPORT", "000000009"]
      *           ["16,409,,,123456789,thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark,TEXT OF SUCH IMPORT", "thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark"]
      */
@@ -868,7 +870,12 @@ final class TransactionParserTest extends RecordParserTestCase
 
     /**
      * @testWith ["16,409,,,123456789,9876+54321,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789,+_)(*&^%$,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,9876)54321,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,9876(54321,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,9876*54321,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,9876^54321,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,9876%54321,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,9876$54321,TEXT OF SUCH IMPORT"]
      */
     public function testCustomerReferenceNumberInvalid(string $line): void
     {

--- a/tests/Parsers/TransactionParserTest.php
+++ b/tests/Parsers/TransactionParserTest.php
@@ -851,6 +851,7 @@ final class TransactionParserTest extends RecordParserTestCase
      *           ["16,409,,,123456789,_,TEXT OF SUCH IMPORT", "_"]
      *           ["16,409,,,123456789,foo & bar,TEXT OF SUCH IMPORT", "foo & bar"]
      *           ["16,409,,,123456789,for acct #1337,TEXT OF SUCH IMPORT", "for acct #1337"]
+     *           ["16,409,,,123456789,for bob's account,TEXT OF SUCH IMPORT", "for bob's account"]
      *           ["16,409,,,123456789,000000009,TEXT OF SUCH IMPORT", "000000009"]
      *           ["16,409,,,123456789,thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark,TEXT OF SUCH IMPORT", "thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark"]
      */


### PR DESCRIPTION
We were previously using a modestly strict interpretation of the specification which did not permit `&`, `#`, or `'` characters to be embedded within a Transaction (type-16) record's Customer Reference Number field. This was causing problems with data encountered in the real world. This commit makes our parser more permissive when it comes these additional non-alphanumeric characters in this supposedly alphanumeric field.

Fixes #10. Closes #11.

Automated Test Results:

OK (1586 tests, 2687 assertions)