### PR TITLE
Allow + sign for item count

### DIFF
--- a/src/Parsers/AccountHeaderParser.php
+++ b/src/Parsers/AccountHeaderParser.php
@@ -218,7 +218,7 @@ final class AccountHeaderParser extends AbstractRecordParser
 
         $accountInformationOrStatus['itemCount'] =
             $this->shiftAndParseField('Item Count')
-                 ->match('/^\d+$/', 'must be unsigned integer when provided')
+                 ->match('/^\+?\d+$/', 'must be positive integer when provided')
                  ->int(default: null);
 
         $accountInformationOrStatus['fundsType']

--- a/tests/Parsers/AccountHeaderParserTest.php
+++ b/tests/Parsers/AccountHeaderParserTest.php
@@ -857,9 +857,15 @@ final class AccountHeaderParserTest extends RecordParserTestCase
         $this->parser['summaryAndStatusInformation'];
     }
 
-    public function testSummaryAndStatusInformationSummaryItemCountValid(): void
+    /**
+     * @testWith ["03,0975312468,,190,500000,4,0/"]
+     *           ["03,0975312468,,190,500000,04,0/"]
+     *           ["03,0975312468,,190,500000,+4,0/"]
+     *           ["03,0975312468,,190,500000,+04,0/"]
+     */
+    public function testSummaryAndStatusInformationSummaryItemCountValid(string $line): void
     {
-        $this->parser->pushLine('03,0975312468,,190,500000,4,0/');
+        $this->parser->pushLine($line);
         $this->assertEquals(4, $this->parser['summaryAndStatusInformation'][0]['itemCount']);
     }
 

--- a/tests/Parsers/AccountHeaderParserTest.php
+++ b/tests/Parsers/AccountHeaderParserTest.php
@@ -871,7 +871,6 @@ final class AccountHeaderParserTest extends RecordParserTestCase
 
     /**
      * @testWith ["03,0975312468,,190,500000,-4,0/"]
-     *           ["03,0975312468,,190,500000,+4,0/"]
      *           ["03,0975312468,,190,500000,4.0,0/"]
      *           ["03,0975312468,,190,500000,a4,0/"]
      *           ["03,0975312468,,190,500000,4b,0/"]
@@ -882,7 +881,7 @@ final class AccountHeaderParserTest extends RecordParserTestCase
         $this->parser->pushLine($line);
 
         $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage('Invalid field type: "Item Count" must be unsigned integer when provided.');
+        $this->expectExceptionMessage('Invalid field type: "Item Count" must be positive integer when provided.');
         $this->parser['summaryAndStatusInformation'];
     }
 


### PR DESCRIPTION
This addresses issue #12.
I'm not sure how standard this is, but I am receiving data from a top Canadian bank that includes a + sign before the item count.