### PR TITLE
TransactionParser: strictly parse Customer Reference Number as alpha-numeric

### DIFF
--- a/src/Parsers/TransactionParser.php
+++ b/src/Parsers/TransactionParser.php
@@ -56,7 +56,7 @@ final class TransactionParser extends AbstractRecordParser
 
         $this->parsed['customerReferenceNumber'] =
             $this->shiftAndParseField('Customer Reference Number')
-                 ->match('/^[a-zA-Z0-9 #&\'_-]+$/', 'must be alpha-numeric when provided')
+                 ->match('/^[a-zA-Z0-9 _-]+$/', 'must be alpha-numeric when provided')
                  ->string(default: null);
 
         $this->parsed['text'] =

--- a/src/Parsers/TransactionParser.php
+++ b/src/Parsers/TransactionParser.php
@@ -56,7 +56,7 @@ final class TransactionParser extends AbstractRecordParser
 
         $this->parsed['customerReferenceNumber'] =
             $this->shiftAndParseField('Customer Reference Number')
-                 ->match('/^[a-zA-Z0-9 _-]+$/', 'must be alpha-numeric when provided')
+                 ->match('/^[a-zA-Z0-9 ]+$/', 'must be alpha-numeric when provided')
                  ->string(default: null);
 
         $this->parsed['text'] =

--- a/src/Parsers/TransactionParser.php
+++ b/src/Parsers/TransactionParser.php
@@ -56,7 +56,7 @@ final class TransactionParser extends AbstractRecordParser
 
         $this->parsed['customerReferenceNumber'] =
             $this->shiftAndParseField('Customer Reference Number')
-                 ->match('/^[a-zA-Z0-9 ]+$/', 'must be alpha-numeric when provided')
+                 ->match('/^[[:alnum:]]+$/', 'must be alpha-numeric when provided')
                  ->string(default: null);
 
         $this->parsed['text'] =

--- a/tests/Parsers/TransactionParserTest.php
+++ b/tests/Parsers/TransactionParserTest.php
@@ -841,14 +841,6 @@ final class TransactionParserTest extends RecordParserTestCase
      *           ["16,409,,,123456789, 98765wxyz,TEXT OF SUCH IMPORT", " 98765wxyz"]
      *           ["16,409,,,123456789,98765wxyz ,TEXT OF SUCH IMPORT", "98765wxyz "]
      *           ["16,409,,,123456789, ,TEXT OF SUCH IMPORT", " "]
-     *           ["16,409,,,123456789,98765-wxyz,TEXT OF SUCH IMPORT", "98765-wxyz"]
-     *           ["16,409,,,123456789,-98765wxyz,TEXT OF SUCH IMPORT", "-98765wxyz"]
-     *           ["16,409,,,123456789,98765wxyz-,TEXT OF SUCH IMPORT", "98765wxyz-"]
-     *           ["16,409,,,123456789,-,TEXT OF SUCH IMPORT", "-"]
-     *           ["16,409,,,123456789,98765_wxyz,TEXT OF SUCH IMPORT", "98765_wxyz"]
-     *           ["16,409,,,123456789,_98765wxyz,TEXT OF SUCH IMPORT", "_98765wxyz"]
-     *           ["16,409,,,123456789,98765wxyz_,TEXT OF SUCH IMPORT", "98765wxyz_"]
-     *           ["16,409,,,123456789,_,TEXT OF SUCH IMPORT", "_"]
      *           ["16,409,,,123456789,000000009,TEXT OF SUCH IMPORT", "000000009"]
      *           ["16,409,,,123456789,thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark,TEXT OF SUCH IMPORT", "thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark"]
      */
@@ -867,7 +859,9 @@ final class TransactionParserTest extends RecordParserTestCase
     }
 
     /**
-     * @testWith ["16,409,,,123456789,9876+54321,TEXT OF SUCH IMPORT"]
+     * @testWith ["16,409,,,123456789,9876_54321,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,9876+54321,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,9876-54321,TEXT OF SUCH IMPORT"]
      *           ["16,409,,,123456789,+_)(*&^%$,TEXT OF SUCH IMPORT"]
      */
     public function testCustomerReferenceNumberInvalid(string $line): void

--- a/tests/Parsers/TransactionParserTest.php
+++ b/tests/Parsers/TransactionParserTest.php
@@ -836,6 +836,7 @@ final class TransactionParserTest extends RecordParserTestCase
      *           ["16,409,,,123456789,rstuvwxyz,TEXT OF SUCH IMPORT", "rstuvwxyz"]
      *           ["16,409,,,123456789,98765wxyz,TEXT OF SUCH IMPORT", "98765wxyz"]
      *           ["16,409,,,123456789,wxyz98765,TEXT OF SUCH IMPORT", "wxyz98765"]
+     *           ["16,409,,,123456789,WXyz98765,TEXT OF SUCH IMPORT", "WXyz98765"]
      *           ["16,409,,,123456789,000000009,TEXT OF SUCH IMPORT", "000000009"]
      *           ["16,409,,,123456789,thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark,TEXT OF SUCH IMPORT", "thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark"]
      */

--- a/tests/Parsers/TransactionParserTest.php
+++ b/tests/Parsers/TransactionParserTest.php
@@ -849,9 +849,6 @@ final class TransactionParserTest extends RecordParserTestCase
      *           ["16,409,,,123456789,_98765wxyz,TEXT OF SUCH IMPORT", "_98765wxyz"]
      *           ["16,409,,,123456789,98765wxyz_,TEXT OF SUCH IMPORT", "98765wxyz_"]
      *           ["16,409,,,123456789,_,TEXT OF SUCH IMPORT", "_"]
-     *           ["16,409,,,123456789,foo & bar,TEXT OF SUCH IMPORT", "foo & bar"]
-     *           ["16,409,,,123456789,for acct #1337,TEXT OF SUCH IMPORT", "for acct #1337"]
-     *           ["16,409,,,123456789,for bob's account,TEXT OF SUCH IMPORT", "for bob's account"]
      *           ["16,409,,,123456789,000000009,TEXT OF SUCH IMPORT", "000000009"]
      *           ["16,409,,,123456789,thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark,TEXT OF SUCH IMPORT", "thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark"]
      */
@@ -871,12 +868,7 @@ final class TransactionParserTest extends RecordParserTestCase
 
     /**
      * @testWith ["16,409,,,123456789,9876+54321,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789,9876)54321,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789,9876(54321,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789,9876*54321,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789,9876^54321,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789,9876%54321,TEXT OF SUCH IMPORT"]
-     *           ["16,409,,,123456789,9876$54321,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,+_)(*&^%$,TEXT OF SUCH IMPORT"]
      */
     public function testCustomerReferenceNumberInvalid(string $line): void
     {

--- a/tests/Parsers/TransactionParserTest.php
+++ b/tests/Parsers/TransactionParserTest.php
@@ -836,11 +836,6 @@ final class TransactionParserTest extends RecordParserTestCase
      *           ["16,409,,,123456789,rstuvwxyz,TEXT OF SUCH IMPORT", "rstuvwxyz"]
      *           ["16,409,,,123456789,98765wxyz,TEXT OF SUCH IMPORT", "98765wxyz"]
      *           ["16,409,,,123456789,wxyz98765,TEXT OF SUCH IMPORT", "wxyz98765"]
-     *           ["16,409,,,123456789,WXyz98765,TEXT OF SUCH IMPORT", "WXyz98765"]
-     *           ["16,409,,,123456789,98765 wxyz,TEXT OF SUCH IMPORT", "98765 wxyz"]
-     *           ["16,409,,,123456789, 98765wxyz,TEXT OF SUCH IMPORT", " 98765wxyz"]
-     *           ["16,409,,,123456789,98765wxyz ,TEXT OF SUCH IMPORT", "98765wxyz "]
-     *           ["16,409,,,123456789, ,TEXT OF SUCH IMPORT", " "]
      *           ["16,409,,,123456789,000000009,TEXT OF SUCH IMPORT", "000000009"]
      *           ["16,409,,,123456789,thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark,TEXT OF SUCH IMPORT", "thelengthofthecustomerreferencenumberisnotlimitedbutshouldprobablybenotmorethan76charactersbecausewhywouldyoueverneedmorethanthatquestionmark"]
      */
@@ -859,10 +854,13 @@ final class TransactionParserTest extends RecordParserTestCase
     }
 
     /**
-     * @testWith ["16,409,,,123456789,9876_54321,TEXT OF SUCH IMPORT"]
+     * @testWith ["16,409,,,123456789, 987654321,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,987654321 ,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789,9876_54321,TEXT OF SUCH IMPORT"]
      *           ["16,409,,,123456789,9876+54321,TEXT OF SUCH IMPORT"]
      *           ["16,409,,,123456789,9876-54321,TEXT OF SUCH IMPORT"]
      *           ["16,409,,,123456789,+_)(*&^%$,TEXT OF SUCH IMPORT"]
+     *           ["16,409,,,123456789, ,TEXT OF SUCH IMPORT"]
      */
     public function testCustomerReferenceNumberInvalid(string $line): void
     {


### PR DESCRIPTION
Previously we tried to loosen the strictness of our parsing of the Customer Reference Number to suit a specific bank. This was a bad idea. This PR reverts those changes and restores our parsing of the Customer Reference Number for transaction records to be based on the spec, which indicates it should be alpha-numeric (which definitely does not include things like spaces, ampersands, octothorpes, dashes, and such).